### PR TITLE
+ CDN hosting for jQuery

### DIFF
--- a/public/symbols.html
+++ b/public/symbols.html
@@ -7,7 +7,7 @@
     <meta name="keywords" content="math,LaTeX,productivity,typesetting,science,machine learning,PhD">
     <link rel="stylesheet" type="text/css" href="css/style.css">
     <link rel="stylesheet" type="text/css" href="css/jquery.gritter.css" />
-    <script type='text/javascript' src="js/jquery-1.4.2.min.js"></script>
+    <script type='text/javascript' src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.4.2/jquery.js"></script>
     <script type="text/javascript" src="js/jquery.gritter.js"></script>
     <script type="text/javascript" src="js/jquery.mustache.js"></script>
     <script type='text/javascript' src="js/jquery-ui-1.7.2.custom.min.js"></script>


### PR DESCRIPTION
https://cdnjs.com/#jquery happens to have older versions.

You could use CDNs more if you are willing to update to newer versions.  (Save hosting money, faster loading)  http://www.jsdelivr.com/ may host other scripts not on cdnjs.

BTW, [Lo-Dash](https://github.com/bestiejs/lodash) tends to be a bit faster than Underscore, & is more compatible with older browsers.
