### PR TITLE
added mathbb symbols for group notation i.e. Natural numbers, reals e…

### DIFF
--- a/lib/latex/symbols.yaml
+++ b/lib/latex/symbols.yaml
@@ -1228,6 +1228,32 @@
 - package: bbold
   mathmode:
     - \mathbb{1}
+    - \mathbb{A}
+    - \mathbb{B}
+    - \mathbb{C}
+    - \mathbb{D}
+    - \mathbb{E}
+    - \mathbb{F}
+    - \mathbb{G}
+    - \mathbb{H}
+    - \mathbb{I}
+    - \mathbb{J}
+    - \mathbb{K}
+    - \mathbb{L}
+    - \mathbb{M}
+    - \mathbb{N}
+    - \mathbb{O}
+    - \mathbb{P}
+    - \mathbb{Q}
+    - \mathbb{R}
+    - \mathbb{S}
+    - \mathbb{T}
+    - \mathbb{U}
+    - \mathbb{V}
+    - \mathbb{W}
+    - \mathbb{X}
+    - \mathbb{Y}
+    - \mathbb{Z}
 - package: dsfont
   mathmode:
     - \mathds{1}


### PR DESCRIPTION
I realized that Detexify doesn't have support for mathbb symbols which are different than mathds symbols, in that they represent groups in Mathematics. I added them I think in the appropriate place.

Let me know if I did everything correctly.

Cheers,
Sean