### PR TITLE
Disable autocomplete, autocorrect, autocapitalize

### DIFF
--- a/source/symbols.haml
+++ b/source/symbols.haml
@@ -52,7 +52,7 @@ js: symbols
           / <option value='samples'>number of samples</option>
       #filter
         Filter by
-        %input{:type => "text"}/
+        %input{:type => "text", :autocomplete=>"off", :autocorrect=>"off", :autocapitalize=>"off", :spellcheck=>"false"}/
     #symbols--loading
       .spinner
       loading...


### PR DESCRIPTION
On mobile, prevent keyboards from changing text (i.e. type "alpha" -> "Alpha" which doesn't return any results)

As per https://davidwalsh.name/disable-autocorrect