### PR TITLE
Add ability to copy LaTeX command

### DIFF
--- a/source/javascripts/classify.coffee
+++ b/source/javascripts/classify.coffee
@@ -40,6 +40,27 @@ $ ->
 
     return
 
+  $(".symbol-list").on "click", "li", ->
+    command = $("code.command", this)[0]
+
+    range = document.createRange()
+    range.selectNode(command)
+
+    selection = window.getSelection()
+    selection.removeAllRanges()
+    selection.addRange(range)
+
+    try
+      if document.execCommand("copy")
+        range.collapse() # Remove selection if copy succeeded
+
+        $(this)
+          .addClass "flash"
+          .on "animationend", ->
+            $(this).removeClass("flash")
+    catch error
+      console.error("Your browser doesn't support the copy command. Use CTRL + V instead.")
+
   # Canvas
   c = $.canvassify("#tafel",
     callback: classify

--- a/source/javascripts/classify.coffee
+++ b/source/javascripts/classify.coffee
@@ -52,14 +52,14 @@ $ ->
 
     try
       if document.execCommand("copy")
-        range.collapse() # Remove selection if copy succeeded
+        selection.collapse(null) # Remove selection if copy succeeded
 
         $(this)
           .addClass "flash"
           .on "animationend", ->
             $(this).removeClass("flash")
     catch error
-      console.error("Your browser doesn't support the copy command. Use CTRL + V instead.")
+      console.error("Your browser doesn't support the copy command. Use CTRL + V instead.", error)
 
   # Canvas
   c = $.canvassify("#tafel",

--- a/source/javascripts/classify.coffee
+++ b/source/javascripts/classify.coffee
@@ -59,7 +59,7 @@ $ ->
           .on "animationend", ->
             $(this).removeClass("flash")
     catch error
-      console.error("Your browser doesn't support the copy command. Use CTRL + V instead.", error)
+      console.error("Your browser doesn't support the copy command. Use CTRL + C instead.", error)
 
   # Canvas
   c = $.canvassify("#tafel",

--- a/source/javascripts/shared/shared.coffee
+++ b/source/javascripts/shared/shared.coffee
@@ -23,7 +23,7 @@
 
   template = """
   {{#symbols}}
-  <li id="{{id}}">
+  <li id="{{id}}" title="Click to copy the command">
     <div class="symbol">
       <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" class="{{css_class}}">
     </div>

--- a/source/stylesheets/_symbol-list.sass
+++ b/source/stylesheets/_symbol-list.sass
@@ -12,6 +12,9 @@ ul.symbol-list
     padding: 0
     overflow: hidden
 
+    &.flash
+      animation: flash 1s linear
+
     .info
       display: table-cell
       vertical-align: middle
@@ -39,7 +42,16 @@ ul.symbol-list
 
     &:hover
       background-color: whitesmoke
+      cursor: pointer
 
     &.active:hover,
     &.active
       background-color: cornsilk
+
+@keyframes flash
+  0%
+    background-color: whitesmoke
+  10%
+    background-color: #EEE
+  100%
+    background-color: whitesmoke


### PR DESCRIPTION
Clicking a symbol's information box will copy the LaTeX command to the user's clipboard.

Fixes #1

![Screenshot](https://user-images.githubusercontent.com/706385/79494348-26b79e80-8023-11ea-9eb2-c3f82a2c4fb5.png)
